### PR TITLE
Dont print during .zshrc execution

### DIFF
--- a/cd-ls.plugin.zsh
+++ b/cd-ls.plugin.zsh
@@ -1,8 +1,13 @@
+zstyle ':cd-ls:*' init_complete false
+
 # 'ls' after every 'cd'
 if ! (( $chpwd_functions[(I)chpwd_cdls] )); then
   chpwd_functions+=(chpwd_cdls)
 fi
 function chpwd_cdls() {
+  if ! zstyle -T ':cd-ls:*' init_complete; then
+    return
+  fi
   if [[ -o interactive ]]; then
     emulate -L zsh
     eval ${CD_LS_COMMAND:-ls}


### PR DESCRIPTION
Dont print during .zshrc execution or else powerlevel10k gives you a warning
This fixes in case you have a `cd` in your .zshrc
Add `zstyle ':cd-ls:*' init_complete true` to bottom of your .zshrc